### PR TITLE
fix(hooks): guard strings/cat against set -e abort in pre-push

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -134,9 +134,9 @@ while read local_ref local_sha remote_ref remote_sha; do
         fi
 
         if [ "$is_binary" = true ]; then
-          file_text=$(strings "$file" 2>/dev/null)
+          file_text=$(strings "$file" 2>/dev/null || echo "")
         else
-          file_text=$(cat "$file" 2>/dev/null)
+          file_text=$(cat "$file" 2>/dev/null || echo "")
         fi
 
         # Check for hardcoded user paths.


### PR DESCRIPTION
## Summary
- Add `|| echo ""` fallback to `strings` and `cat` command substitutions in pre-push hook
- Without this, if `strings` is not installed (e.g. minimal Docker/CI images), `set -e` silently aborts the script with exit 127, blocking the push with no message

## Test plan
- [ ] Verify pre-push hook runs without error on normal push