### PR TITLE
fix(ci): use threads pool instead of forks to prevent worker exit crashes

### DIFF
--- a/.config/vitest.config.mts
+++ b/.config/vitest.config.mts
@@ -65,18 +65,13 @@ const vitestConfig = defineConfig({
         : [toGlobPath(path.resolve(projectRoot, 'test/npm/**'))]),
     ],
     reporters: ['default'],
-    pool: process.env.CI ? 'forks' : 'threads',
+    pool: 'threads',
     poolOptions: {
       threads: {
-        maxThreads: 16,
-        minThreads: 4,
+        maxThreads: process.env.CI ? 4 : 16,
+        minThreads: process.env.CI ? 2 : 4,
         isolate: false,
         useAtomics: true,
-      },
-      forks: {
-        maxForks: process.env.CI ? 4 : 16,
-        minForks: process.env.CI ? 2 : 4,
-        isolate: true,
       },
     },
     teardownTimeout: 30_000,


### PR DESCRIPTION
## Summary

- Switch vitest pool from `forks` (CI) to `threads` everywhere
- Forks pool causes `Worker exited unexpectedly` errors on ubuntu-latest after the source resolution change, because fork processes loading TypeScript via the transform pipeline crash during exit
- Threads pool is faster (18s vs 36s locally) and doesn't have the exit crash issue