### PR TITLE
fix(config): align .npmrc and pnpm-workspace.yaml for pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,3 @@
-# Minimum release age for npm v11+ (days).
+# npm v11+ settings (not pnpm — pnpm v11 only reads auth/registry from .npmrc).
+ignore-scripts=true
 min-release-age=7
-
-trust-policy=no-downgrade
-trust-policy-exclude[]=@yarnpkg/core@4.5.0
-trust-policy-exclude[]=@yarnpkg/libzip@3.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
-ignoreDependencyScripts: true
-linkWorkspacePackages: false
 resolutionMode: highest
+trustPolicy: no-downgrade
+trustPolicyExclude:
+  - '@yarnpkg/core@4.5.0'
+  - '@yarnpkg/libzip@3.2.2'
 
 allowBuilds:
   esbuild: true
@@ -56,12 +58,11 @@ patchedDependencies:
   node-gyp@11.5.0: patches/node-gyp@11.5.0.patch
   minipass-sized@1.0.3: patches/minipass-sized@1.0.3.patch
 
-settings:
-  # Wait 7 days (10080 minutes) before installing newly published packages.
-  minimumReleaseAge: 10080
-  minimumReleaseAgeExclude:
-    - '@anthropic-ai/claude-code@2.1.92'
-    - '@socketaddon/*'
-    - '@socketbin/*'
-    - '@socketregistry/*'
-    - '@socketsecurity/*'
+# Wait 7 days (10080 minutes) before installing newly published packages.
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@anthropic-ai/claude-code@2.1.92'
+  - '@socketaddon/*'
+  - '@socketbin/*'
+  - '@socketregistry/*'
+  - '@socketsecurity/*'


### PR DESCRIPTION
## Summary
- Remove pnpm settings from `.npmrc` (pnpm v11 only reads auth/registry from `.npmrc`)
- Add `trustPolicy`/`trustPolicyExclude` to `pnpm-workspace.yaml` (migrated from `.npmrc`)
- Remove invalid `ignoreDependencyScripts` and `linkWorkspacePackages` settings
- Un-nest `minimumReleaseAge` from incorrect `settings:` block
- Keep `ignore-scripts` and `min-release-age` in `.npmrc` for npm compatibility

## Test plan
- [x] Verify `pnpm install` works locally
- [ ] Verify CI passes