### PR TITLE
chore(ci): bump socket-registry action refs to main (34fef52b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
     with:
       test-script: 'pnpm exec vitest --config .config/vitest.config.mts run'
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
 
       - name: Build project
         run: pnpm run build

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
     with:
       debug: ${{ inputs.debug }}
       package-name: '@socketsecurity/lib'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
 
       - name: Check for npm updates
         id: check
@@ -48,7 +48,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
 
       - name: Create update branch
         id: branch
@@ -60,7 +60,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -295,7 +295,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@eb53b17da1dbb6170e3df74d28ec2e1e45678c70 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary

Picks up the latest reusable workflow + action changes from [socket-registry](https://github.com/SocketDev/socket-registry) by bumping all pinned SHAs to `34fef52be917f89dbbeb464860f2aaf0f3812c40`.

## Changes included

- `provenance.yml` permissions scoped to the publish job (was workflow-level)
- `weekly-update.yml` template-injection fix (`${{ github.repository }}` now flows through `env:`)
- Concurrency block added to weekly-update
- Various script/hook fixes that land in the reusable actions' dependency tree

## Test plan

- [ ] CI passes