### PR TITLE
chore(ci): bump socket-registry actions to 13684cd8 (gh telemetry opt-out)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@13684cd82b9fdf2c389e2e808504014362f39655 # main
     with:
       test-script: 'pnpm exec vitest --config .config/vitest.config.mts run'
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
 
       - name: Build project
         run: pnpm run build

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@13684cd82b9fdf2c389e2e808504014362f39655 # main
     with:
       debug: ${{ inputs.debug }}
       package-name: '@socketsecurity/lib'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
 
       - name: Check for npm updates
         id: check
@@ -54,7 +54,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@13684cd82b9fdf2c389e2e808504014362f39655 # main
 
       - name: Create update branch
         id: branch
@@ -66,7 +66,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@13684cd82b9fdf2c389e2e808504014362f39655 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@13684cd82b9fdf2c389e2e808504014362f39655 # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary

- Bumps all `SocketDev/socket-registry/.github/*` pins from `ebf1b48f` to `13684cd8` (current propagation SHA).
- New SHA opts out of GitHub's on-by-default `gh` CLI telemetry via `DO_NOT_TRACK=1` and `GH_TELEMETRY=0` (written to `\$GITHUB_ENV` in the shared `setup` composite action).

## Test plan

- [ ] CI runs green on the bumped pins.