### PR TITLE
chore(ci): bump socket-registry refs to 0371e83f

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
     with:
       test-script: 'pnpm exec vitest --config .config/vitest.config.mts run'
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
 
       - name: Build project
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@444b6415a78a44d50066a0eb7ef219a751224561 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
     with:
       test-script: 'pnpm exec vitest --config .config/vitest.config.mts run'
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@444b6415a78a44d50066a0eb7ef219a751224561 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
 
       - name: Build project
         run: pnpm run build

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
     with:
       debug: ${{ inputs.debug }}
       package-name: '@socketsecurity/lib'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@444b6415a78a44d50066a0eb7ef219a751224561 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
     with:
       debug: ${{ inputs.debug }}
       package-name: '@socketsecurity/lib'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
 
       - name: Check for npm updates
         id: check
@@ -54,7 +54,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
 
       - name: Create update branch
         id: branch
@@ -66,7 +66,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         if: always()
 
   notify:

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@444b6415a78a44d50066a0eb7ef219a751224561 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
 
       - name: Check for npm updates
         id: check
@@ -54,7 +54,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@444b6415a78a44d50066a0eb7ef219a751224561 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
 
       - name: Create update branch
         id: branch
@@ -66,7 +66,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@444b6415a78a44d50066a0eb7ef219a751224561 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@444b6415a78a44d50066a0eb7ef219a751224561 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
         if: always()
 
   notify:


### PR DESCRIPTION
Bumps `SocketDev/socket-registry` workflow/action pins to `0371e83f`.

This is the Layer 3 propagation SHA from socket-registry's recent cascade adding a runtime guard to the install action: it now fails fast with an actionable message when the consumer's `@socketsecurity/lib` is below the latest version published to npm. Below-floor versions ship a stubbed pacote fetcher that throws inside `downloadPackage` when the install action provisions ecc-agentshield.

socket-lib already pins `@socketsecurity/lib-stable` at `5.24.0` (the current npm latest), so this is a mechanical bump — no consumer code changes.

## Test plan
- [ ] CI pipeline (check + matrix tests) passes
- [ ] Audit GitHub Actions check passes