### PR TITLE
chore(ci): cascade socket-registry pin to 1594d82b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@1594d82bb7b61015b615aad588c4d4763cb64194 # main
     with:
       test-script: 'pnpm exec vitest --config .config/vitest.config.mts run'
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@1594d82bb7b61015b615aad588c4d4763cb64194 # main
 
       - name: Build project
         run: pnpm run build

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@1594d82bb7b61015b615aad588c4d4763cb64194 # main
     with:
       debug: ${{ inputs.debug }}
       package-name: '@socketsecurity/lib'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@1594d82bb7b61015b615aad588c4d4763cb64194 # main
 
       - name: Check for npm updates
         id: check
@@ -54,7 +54,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@1594d82bb7b61015b615aad588c4d4763cb64194 # main
 
       - name: Create update branch
         id: branch
@@ -66,7 +66,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@1594d82bb7b61015b615aad588c4d4763cb64194 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -303,7 +303,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@1594d82bb7b61015b615aad588c4d4763cb64194 # main
         if: always()
 
   notify:


### PR DESCRIPTION
Bumps socket-registry workflow pins from ea1986b8019fedee5fb38b485690b13ad8e0217f to 1594d82bb7b61015b615aad588c4d4763cb64194.

Picks up [PR #279](https://github.com/SocketDev/socket-registry/pull/279) which adds a bootstrap-from-registry step to install/action.yml — pre-seeds `@socketsecurity/lib` into `node_modules/` from the npm registry tarball before `pnpm install` runs, with firewall-api.socket.dev verification before download.

Cascade chain (in socket-registry): install (Layer 1, #279) → setup-and-install (Layer 2b, #281) → reusable workflows (Layer 3, #282) → _local wrappers (Layer 4, #283).