### PR TITLE
fix(build): scope external() to own src/external tree

### DIFF
--- a/.config/rolldown.config.mts
+++ b/.config/rolldown.config.mts
@@ -63,12 +63,30 @@ export const buildConfig: RolldownOptions = {
   // rewriting consumers to `.default` (the source uses `module.exports =`, so
   // the injected `.default` would be undefined at runtime — externalizing
   // avoids that).
-  external: (id: string) =>
-    // Treat any path with an `external/` segment as external: preceded by a
-    // separator of either platform or by the string start, and followed by a
-    // separator.
-    /(?:[/\\]|^)external[/\\]/.test(id) ||
-    (!id.startsWith('.') && !path.isAbsolute(id)),
+  external: (id: string, importer?: string | undefined) => {
+    // Bare specifiers (deps) stay external — per-file transpile, consumers
+    // install them.
+    if (!id.startsWith('.') && !path.isAbsolute(id)) {
+      return true
+    }
+    // THIS repo's `src/external/*` shims, matched by resolved path. A blanket
+    // `external/`-segment test also matches a *dependency's* nested
+    // `dist/external/*` (e.g. an inlined package vendoring its own externals),
+    // externalizing modules that were meant to be bundled and emitting
+    // relative requires into files that don't exist next to the output —
+    // exactly the class of break that shipped socket-cli 1.1.151's
+    // "Cannot find module 'form-data'". Scoping by resolved prefix keeps the
+    // predicate to the tree it owns.
+    const resolved = path.isAbsolute(id)
+      ? id
+      : importer
+        ? path.resolve(path.dirname(importer), id)
+        : undefined
+    return (
+      resolved !== undefined &&
+      resolved.startsWith(path.join(srcPath, 'external') + path.sep)
+    )
+  },
   input,
   output: {
     banner: '"use strict";\n/* Socket Lib - Built with rolldown */',

--- a/test/unit/config/rolldown.config.test.mts
+++ b/test/unit/config/rolldown.config.test.mts
@@ -1,0 +1,68 @@
+/**
+ * @file Tests for the main build's `external()` predicate. It must externalize
+ *   bare specifiers (deps) and THIS repo's own `src/external/*` shims — and
+ *   nothing else. A blanket `external/`-segment match also catches a
+ *   dependency's nested `dist/external/*` (an inlined package vendoring its
+ *   own externals), externalizing modules that were meant to be bundled and
+ *   emitting relative requires into files that don't exist next to the
+ *   output — the class of break that shipped socket-cli 1.1.151's
+ *   "Cannot find module 'form-data'".
+ */
+
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { buildConfig } from '../../../.config/rolldown.config.mts'
+
+const rootPath = path.resolve(import.meta.dirname, '../../..')
+const srcPath = path.join(rootPath, 'src')
+
+const external = buildConfig.external as (
+  id: string,
+  importer?: string | undefined,
+) => boolean
+
+describe('main build external() predicate', () => {
+  it('externalizes bare specifiers', () => {
+    expect(external('semver')).toBe(true)
+    expect(external('@socketsecurity/lib-stable/env/boolean')).toBe(true)
+  })
+
+  it('externalizes own src/external shims by relative import', () => {
+    const importer = path.join(srcPath, 'globs/_internal.ts')
+    expect(external('../external/fast-glob.js', importer)).toBe(true)
+    expect(external('../external/picomatch.js', importer)).toBe(true)
+  })
+
+  it('externalizes own src/external shims by absolute path', () => {
+    expect(external(path.join(srcPath, 'external/semver.js'))).toBe(true)
+  })
+
+  it('bundles ordinary relative imports', () => {
+    const importer = path.join(srcPath, 'globs/_internal.ts')
+    expect(external('./defaults', importer)).toBe(false)
+    expect(external('../paths/normalize', importer)).toBe(false)
+  })
+
+  it("does NOT externalize a dependency's nested dist/external", () => {
+    // The regression pin: these carry an `external/` segment but live inside
+    // node_modules, not this repo's src/external.
+    const nested = path.join(
+      rootPath,
+      'node_modules/@socketsecurity/lib/dist/external/pony-cause.js',
+    )
+    expect(external(nested)).toBe(false)
+    const importerInDep = path.join(
+      rootPath,
+      'node_modules/@socketsecurity/lib/dist/cacache/_internal.js',
+    )
+    expect(external('../external/cacache', importerInDep)).toBe(false)
+  })
+
+  it('does not externalize a relative external path with no importer', () => {
+    // Unresolvable relative id: bundling (false) is the safe default; the
+    // entry map never feeds relative ids without importers in practice.
+    expect(external('../external/fast-glob.js')).toBe(false)
+  })
+})


### PR DESCRIPTION
The main build's `external()` treats **any** path with an `external/` segment as external. That regex also matches a *dependency's* nested `dist/external/*` — an inlined package vendoring its own externals — externalizing modules that were meant to be bundled and emitting relative requires into files that don't exist next to the output.

This isn't hypothetical: socket-sdk-js copied this predicate while adopting the `src/external/` vendoring convention ([socket-sdk-js#681](https://github.com/SocketDev/socket-sdk-js/pull/681)) and its build broke exactly this way — the SDK inlines `@socketsecurity/lib`, and the blanket match externalized lib's own `dist/external/pony-cause`, producing `Could not resolve "../node_modules/.../dist/external/pony-cause"`. The same class of break (a specifier shipped with nothing behind it) is what took down `socket@1.1.151`'s uploads for a customer.

**Fix:** match by **resolved path under this repo's `src/external/`** instead. Bare specifiers stay external exactly as before; own shims are recognized whether imported relatively (`../external/fast-glob.js` from `src/globs/_internal.ts`) or absolutely; anything under a dependency's `node_modules` no longer qualifies.

**Behavior-preserving, proven rather than argued:** the emitted `dist` is **byte-identical** across every `.js` file before and after the change (sha256 manifest of the full tree: `3996e6c9deea39ca` both ways), and the build's own validators pass unchanged (610 public exports, 48/51 external-module interop checks). Six unit tests pin the predicate semantics, including the nested-`node_modules` regression case.

## Actions needed

- Review + merge. Nothing downstream depends on ordering — the emitted output is identical, so this can land whenever.

